### PR TITLE
Rename CLI command in README for consistency and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You will be prompted to enter the destination folder and select the folders you 
 Alternatively, you can use `npx` to run the CLI tool without installing it globally:
 
 ```sh
-npx scss-scaffolder-cli
+npx scss-cli
 ```
 
 ## Options ⚙️


### PR DESCRIPTION
Update the CLI command in the README to improve clarity and maintain consistency throughout the documentation.